### PR TITLE
 Fix Posix Builds

### DIFF
--- a/src/protobridge.cpp
+++ b/src/protobridge.cpp
@@ -13,7 +13,7 @@ struct ProtoBridgeContext
 
 #if VM_TRACE
     VerilatedVcdC trace;
-    uint64_t      time;
+    vluint64_t    time;
 #endif
 };
 


### PR DESCRIPTION
Posix builds may fail when using uint64_t because of ambiguous overload
errors. This change uses the typedef from verilator directly, to avoid
any issues.